### PR TITLE
fix: edit taxonomies

### DIFF
--- a/inc/class-admin.php
+++ b/inc/class-admin.php
@@ -174,12 +174,16 @@ class Admin {
 			// Get term.
 			$term = get_term_by( 'term_taxonomy_id', $term_id, wp_unslash( $_GET['taxonomy'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-			// Get term permalink.
-			$permalink = get_term_link( $term->term_id ?? 0 );
+			/**
+			 * Implementing the same fix from from the forked repo for the new tax edit page error.
+			 * https://github.com/alleyinteractive/wp-irving/blob/bc1efd287875e639e4a641a8ece0d1c5669be9c6/inc/templates/admin-bar.php#L325
+			*/
+			if ( $term instanceof \WP_Term ) {
 
-			// Get the API URL, allowing it to be filtered.
-			$path_url = \WP_Irving\REST_API\Components_Endpoint::get_wp_irving_api_url( $permalink );
-			$path_url = apply_filters( 'wp_irving_term_row_action_path_url', $path_url, $term );
+				// Get the API URL, allowing it to be filtered.
+				$path_url = \WP_Irving\REST_API\Components_Endpoint::get_wp_irving_api_url( get_term_link( $term->term_id ) );
+				$path_url = apply_filters( 'wp_irving_term_row_action_path_url', $path_url, $term );
+			}
 		}
 
 		if (


### PR DESCRIPTION
### Description
Implementing the same fix from https://github.com/alleyinteractive/wp-irving/blob/bc1efd287875e639e4a641a8ece0d1c5669be9c6/inc/templates/admin-bar.php#L325 
To solve the `/wp-irving/inc/endpoints/class-components-endpoint.php` bug which is causing the edit tax page to crash for new taxonomies.

### QA
#### Before checking out to this branch:
- [ ] Go to [lists tax page](https://mittr.wordpress.test/wp-admin/edit-tags.php?taxonomy=tr50_list_year&post_type=company_list_50) from the CMS (or tags, podcasts...)
- [ ] Create a new tax
- [ ] Click `Edit` to edit that new tax
- [ ] Verify that you're able to reproduce the `Recoverable fatal error: Object of class WP_Error could not be converted to string in /srv/www/mittr/public_html/wp-content/client-mu-plugins/wp-irving/inc/endpoints/class-components-endpoint.php on line 452` error 
- [ ] Checkout to this branch from the `./client-mu-plugins/wp-irving/` directory
- [ ] Refresh the same edit page above (where you received this error) and verify that it's now working as expected
- [ ] Verify the same with various tax types (tags, podcasts...)

### Screenshots
#### Before
![before](https://user-images.githubusercontent.com/10087168/120307330-86cadc00-c2db-11eb-862e-5ceb213b72e9.gif)

#### After
![after](https://user-images.githubusercontent.com/10087168/120307349-8cc0bd00-c2db-11eb-9e64-f7a599323f17.gif)
