### PR TITLE
replace deprecated STYLESHEETPATH constant

### DIFF
--- a/inc/templates.php
+++ b/inc/templates.php
@@ -199,7 +199,7 @@ function filter_template_loader() {
  * @return string The path to the found template.
  */
 function locate_template( array $templates ): string {
-	$template_path = STYLESHEETPATH . '/templates/';
+	$template_path = get_stylesheet_directory() . '/templates/';
 
 	/**
 	 * Filter the path to Irving templates.
@@ -250,7 +250,7 @@ function locate_template( array $templates ): string {
  */
 function locate_template_part( string $template ): string {
 
-	$template_part_path = STYLESHEETPATH . '/template-parts/';
+	$template_part_path = get_stylesheet_directory() . '/template-parts/';
 
 	/**
 	 * Filter the path to Irving template partss.


### PR DESCRIPTION
**Jira issue:** [TECH-406](https://technologyreview.atlassian.net/browse/TECH-406)

**Link to feature on test environment:** [irving-alpha.technologyreview.com](https://irving-alpha.technologyreview.com)

**Parent PR:** https://github.com/wpcomvip/mit-technology-review/pull/705

**WP repo PR:** https://github.com/wpcomvip/mit-technology-review/pull/708

## Description:

Replaces the `STYLESHEETPATH` constant, which returns the path to the directory containing the theme stylesheet, with the `get_stylesheet_directory()` function, which does the exact same thing. [The `STYLESHEETPATH` constant was deprecated in WordPress 6.4](https://core.trac.wordpress.org/ticket/18298) and this is the suggested method of replacing the deprecated constant.

## Instructions for Code Review & QA:

Review the WP repo PR to QA this: https://github.com/wpcomvip/mit-technology-review/pull/708

## Release considerations:

This PR should be merged when the WP one gets merged.