### PR TITLE
Add missing class variable declaration

### DIFF
--- a/inc/integrations/class-jwt-auth.php
+++ b/inc/integrations/class-jwt-auth.php
@@ -28,6 +28,13 @@ class JWT_Auth {
 	const KEYPAIR_NAME = 'wp-irving-jwt-auth';
 
 	/**
+	 * Cookie domain.
+	 *
+	 * @var string
+	 */
+	protected $cookie_domain;
+
+	/**
 	 * Class instance.
 	 *
 	 * @var null|self


### PR DESCRIPTION
**Jira issue:** [TECH-434](https://technologyreview.atlassian.net/browse/TECH-434)

**Link to features on test environment:** [wp-develop env: WP Admin](https://wp-develop.technologyreview.com/wp-admin/)

**Corresponding Node PR:** N/A

## Description:

The WP Irving plugin is showing an error:

```
PHP Deprecated:  Creation of dynamic property WP_Irving\JWT_Auth::$cookie_domain is deprecated in /wp/wp-content/client-mu-plugins/wp-irving/inc/integrations/class-jwt-auth.php on line 88
```

This is happening because the `WP_Irving\JWT_Auth` class does not declare the `$cookie_domain` variable before using it.

Not declaring this variable before it's used causes a 'dynamic variable' to be created, which is [deprecated in PHP 8.2](https://php.watch/versions/8.2/dynamic-properties-deprecated).

This PR fixes that by declaring the variable.

## Instructions for Code Review & QA:

1. Open the [WP VIP logs for the develop environment](https://dashboard.wpvip.com/apps/1941/preprod/logs/runtime).
2. Go to the [develop environment WP Admin](https://wp-develop.technologyreview.com/wp-admin/).
3. Check that there are no error messages about `Creation of dynamic property WP_Irving\JWT_Auth::$cookie_domain`.

## Release considerations:

N/A