### PR TITLE
fix PHP warnings

### DIFF
--- a/inc/class-admin.php
+++ b/inc/class-admin.php
@@ -104,7 +104,7 @@ class Admin {
 	 */
 	public function hook_taxonomy_row_actions() {
 		foreach ( get_taxonomies() as $taxonomy ) {
-			add_filter( "${taxonomy}_row_actions", [ $this, 'add_api_link_to_terms' ], 10, 2 );
+			add_filter( "{$taxonomy}_row_actions", [ $this, 'add_api_link_to_terms' ], 10, 2 );
 		}
 	}
 

--- a/inc/integrations/class-jwt-auth.php
+++ b/inc/integrations/class-jwt-auth.php
@@ -188,7 +188,7 @@ class JWT_Auth {
 		// phpcs:ignore
 		setcookie(
 			self::COOKIE_NAME,
-			null,
+			'',
 			-1,
 			'/',
 			$this->cookie_domain


### PR DESCRIPTION
**Jira issue:** [TECH-568](https://technologyreview.atlassian.net/browse/TECH-568) and [TECH-434](https://technologyreview.atlassian.net/browse/TECH-434)

**Link to features on test environment:** [develop env: WP Admin](https://wp-develop.technologyreview.com/wp-admin/)

**Corresponding Node PR:** N/A

## Description:

The WP Irving plugin is showing two PHP warnings:

### 1:

```
PHP message: Deprecated: setcookie(): Passing null to parameter #2 ($value) of type string is deprecated in /var/www/wp-content/client-mu-plugins/wp-irving/inc/integrations/class-jwt-auth.php on line 189
```

This is happening because the `WP_Irving\JWT_Auth::remove_cookie()` function provides a `null` value to the `setcookie()` function's second parameter (the `$value` parameter), and [that parameter expects a string](https://www.php.net/manual/en/function.setcookie.php). Passing `null` to a parameter of type `string` is now deprecated.

This PR fixes that by instead setting the parameter to `''` (an empty string).

### 2:

```
PHP message: PHP Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/wp-content/client-mu-plugins/wp-irving/inc/class-admin.php on line 107
```

This is a simple matter of a changing the `${` in this line to a `{$`:

```diff
- add_filter( "${taxonomy}_row_actions", [ $this, 'add_api_link_to_terms' ], 10, 2 );
+ add_filter( "{$taxonomy}_row_actions", [ $this, 'add_api_link_to_terms' ], 10, 2 );
               ↑
```

## Instructions for Code Review & QA:

1. Open the [WP VIP logs for the `develop` environment](https://dashboard.wpvip.com/apps/1941/develop/logs/runtime).
2. Go to the [`develop` environment WP Admin](https://wp-develop.technologyreview.com/wp-admin/).
3. Check that there are no error messages about `setcookie(): Passing null to parameter #2 ($value)`.
4. Check that there are no error messages about `Using ${var} in strings is deprecated`.

## Release considerations:

N/A